### PR TITLE
Test with maintained Ruby versions

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -14,16 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        ruby: ['2.5', '2.6', '2.7', '3.0', '3.1']
+        ruby: ['2.7', '3.0', '3.1']
         activerecord: ['6.0', '6.1', '7.0']
         experimental: [false]
         exclude:
-        - ruby: '2.5'
-          activerecord: '7.0'
-          experimental: false
-        - ruby: '2.6'
-          activerecord: '7.0'
-          experimental: false
         - ruby: '3.1'
           activerecord: '6.0'
           experimental: false

--- a/audit_loggable.gemspec
+++ b/audit_loggable.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ["lib"]
 
-  spec.required_ruby_version = ">= 2.5"
+  spec.required_ruby_version = ">= 2.7"
 
   spec.add_dependency "activerecord",  ">= 6.0"
   spec.add_dependency "activesupport", ">= 6.0"


### PR DESCRIPTION
I think it would be acceptable to remove EOL Ruby versions in the CI config.

Refs.
- https://www.ruby-lang.org/en/downloads/branches/