### PR TITLE
Make configurable timezone of timestamp

### DIFF
--- a/.github/workflows/ruby.yml
+++ b/.github/workflows/ruby.yml
@@ -35,4 +35,6 @@ jobs:
         bundle install
         bundle exec appraisal $APPRAISAL bundle install
     - name: Run tests
+      env:
+        TZ: "Asia/Tokyo"
       run: bundle exec appraisal $APPRAISAL rake

--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Options
 | `audit_log_shift_age`           | Integer or String | Same as `shift_age` option of `Logger` class of stdlib.            | `0`       |
 | `audit_log_shift_size`          | Integer           | Same as `shift_size` option of `Logger` class of stdlib.           | `1048576` |
 | `audit_log_shift_period_suffix` | String            | Same as `shift_period_suffix` options of `Logger` class of stdlib. | `%Y%m%d`  |
+| `audit_log_timezone`            | Enum              | The timezone of timestamp. Any value of `:local` or `:utc`.        | `local`  |
 
 ### Extend your model by `AuditLoggable::Extension`
 ``` ruby

--- a/lib/audit_loggable.rb
+++ b/lib/audit_loggable.rb
@@ -21,7 +21,7 @@ module AuditLoggable
     attr_reader :logger
 
     delegate :audit_log_path, :audit_log_shift_age, :audit_log_shift_size, :audit_log_shift_period_suffix,
-             :auditing_enabled,
+             :auditing_enabled, :audit_log_timezone,
              to: :configuration
 
     def configure
@@ -40,7 +40,8 @@ module AuditLoggable
         self.audit_log_path,
         shift_age:           self.audit_log_shift_age,
         shift_size:          self.audit_log_shift_size,
-        shift_period_suffix: self.audit_log_shift_period_suffix
+        shift_period_suffix: self.audit_log_shift_period_suffix,
+        timezone:            self.audit_log_timezone
       )
     end
   end

--- a/lib/audit_loggable/configuration.rb
+++ b/lib/audit_loggable/configuration.rb
@@ -3,13 +3,14 @@
 module AuditLoggable
   class Configuration
     attr_accessor :audit_log_path, :audit_log_shift_age, :audit_log_shift_size, :audit_log_shift_period_suffix,
-                  :auditing_enabled
+                  :auditing_enabled, :audit_log_timezone
 
     def initialize
       self.auditing_enabled = true
       self.audit_log_shift_age = 0
       self.audit_log_shift_size = 1024 * 1024
       self.audit_log_shift_period_suffix = "%Y%m%d"
+      self.audit_log_timezone = :local
     end
   end
 end

--- a/spec/audit_loggable/logger/json_formatter_spec.rb
+++ b/spec/audit_loggable/logger/json_formatter_spec.rb
@@ -2,16 +2,31 @@
 
 RSpec.describe AuditLoggable::Logger::JSONFormatter do
   describe "#call" do
-    subject { described_class.new.call("INFO", time, nil, message) }
+    subject { described_class.new(timezone: timezone).call("INFO", time, nil, message) }
 
     let!(:time) { Time.now.utc }
     let!(:message) { { key: "value" } }
 
-    it "returns json string with newline character" do
-      precision = ::ActiveSupport::JSON::Encoding.time_precision
-      expected_string = %({"timestamp":"#{time.iso8601(precision)}","record":{"key":"value"}}\n)
+    context "when timezone is set to :utc" do
+      let!(:timezone) { :utc }
 
-      expect(subject).to eq expected_string
+      it "returns json string with newline character" do
+        precision = ::ActiveSupport::JSON::Encoding.time_precision
+        expected_string = %({"timestamp":"#{time.getutc.iso8601(precision)}","record":{"key":"value"}}\n)
+
+        expect(subject).to eq expected_string
+      end
+    end
+
+    context "when timezone is set to :local" do
+      let!(:timezone) { :local }
+
+      it "returns json string with newline character" do
+        precision = ::ActiveSupport::JSON::Encoding.time_precision
+        expected_string = %({"timestamp":"#{time.getlocal.iso8601(precision)}","record":{"key":"value"}}\n)
+
+        expect(subject).to eq expected_string
+      end
     end
   end
 end

--- a/spec/audit_loggable/logger_spec.rb
+++ b/spec/audit_loggable/logger_spec.rb
@@ -7,7 +7,8 @@ RSpec.describe AuditLoggable::Logger do
         ::AuditLoggable.audit_log_path,
         shift_age:           ::AuditLoggable.audit_log_shift_age,
         shift_size:          ::AuditLoggable.audit_log_shift_size,
-        shift_period_suffix: ::AuditLoggable.audit_log_shift_period_suffix
+        shift_period_suffix: ::AuditLoggable.audit_log_shift_period_suffix,
+        timezone:            ::AuditLoggable.audit_log_timezone
       )
     end
 


### PR DESCRIPTION
I added `audit_log_timezone` to the configuration.
Set one of following values:
* `:utc`
   ``` json
   {"timestamp":"2022-09-20T15:12:14.575Z","record":{"auditable":{"id":7,"type":"User"},"user":null,"action":"create","changes":"{\"name\":\"dummy user\",\"email\":\"[REDACTED]\"}","remote_address":null,"request_uuid":null}}
   ```
* `:local` **[default]**
   ``` json
   {"timestamp":"2022-09-21T00:10:50.464+09:00","record":{"auditable":{"id":7,"type":"User"},"user":null,"action":"create","changes":"{\"name\":\"dummy user\",\"email\":\"[REDACTED]\"}","remote_address":null,"request_uuid":null}}
   ```