### PR TITLE
Improve `AuditRecord#as_json`

### DIFF
--- a/lib/audit_loggable/audit_record.rb
+++ b/lib/audit_loggable/audit_record.rb
@@ -11,7 +11,7 @@ module AuditLoggable
       @request_uuid = request_uuid
     end
 
-    def as_json(*)
+    def as_json(options = nil)
       {
         auditable: { id: auditable.id, type: auditable.class.polymorphic_name },
         user: user ? { id: user.id, type: user.class.polymorphic_name } : nil,
@@ -19,7 +19,7 @@ module AuditLoggable
         changes: changeset.to_json, # serialize to JSON string
         remote_address: remote_address,
         request_uuid: request_uuid
-      }
+      }.as_json(options)
     end
 
     private

--- a/spec/audit_loggable/audit_record_spec.rb
+++ b/spec/audit_loggable/audit_record_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe AuditLoggable::AuditRecord do
   describe "#as_json" do
     subject { audit_record.as_json }
 
-    let!(:action) { %i[create update destroy] }
+    let!(:action) { %i[create update destroy].sample }
     let!(:remote_address) { ["127.0.0.1", nil].sample }
     let!(:request_uuid) { [SecureRandom.uuid, nil].sample }
 

--- a/spec/audit_loggable/audit_record_spec.rb
+++ b/spec/audit_loggable/audit_record_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe AuditLoggable::AuditRecord do
       it "returns a hash representing audit record that user is setted" do
         expect(subject).to eq(
           {
-            auditable:      { id: 1, type: "Post" },
-            user:           { id: 2, type: "User" },
-            action:         action,
-            changes:        %({"foo":[1,2],"bar":["before","after"]}),
-            remote_address: remote_address,
-            request_uuid:   request_uuid
+            "auditable"      => { "id" => 1, "type" => "Post" },
+            "user"           => { "id" => 2, "type" => "User" },
+            "action"         => action.to_s,
+            "changes"        => %({"foo":[1,2],"bar":["before","after"]}),
+            "remote_address" => remote_address,
+            "request_uuid"   => request_uuid
           }
         )
       end
@@ -49,12 +49,12 @@ RSpec.describe AuditLoggable::AuditRecord do
       it "returns a hash representing audit record that user is nil" do
         expect(subject).to eq(
           {
-            auditable:      { id: 1, type: "Post" },
-            user:           nil,
-            action:         action,
-            changes:        %({"foo":[1,2],"bar":["before","after"]}),
-            remote_address: remote_address,
-            request_uuid:   request_uuid
+            "auditable"      => { "id" => 1, "type" => "Post" },
+            "user"           => nil,
+            "action"         => action.to_s,
+            "changes"        => %({"foo":[1,2],"bar":["before","after"]}),
+            "remote_address" => remote_address,
+            "request_uuid"   => request_uuid
           }
         )
       end


### PR DESCRIPTION
It delegates `AuditRecord#as_json` to `Hash#as_json`.